### PR TITLE
Revert "Use roman number for chapters"

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'jekyll'
+gem 'jekyll-roman'

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -19,3 +19,6 @@ defaults:
       path: ""
     values:
       layout: "default"
+
+gems:
+  - jekyll-roman

--- a/docs/_layouts/chapter.html
+++ b/docs/_layouts/chapter.html
@@ -1,6 +1,6 @@
 ---
 layout: default
 ---
-<h1>Chapter {{ page.chapter | roman }}. {{ page.title }}</h1>
+<h1>Chapter {{ 1 | abs | roman }}. {{ page.title }}</h1>
 
 {{ content }}


### PR DESCRIPTION
Forgot to track the plugin file of `jekyll-roman`.